### PR TITLE
doc: Fix the building script in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ All other dependencies are managed by CMake script and git submodule.
 ### Building
 
 ```sh
-$ git submodule update
+$ git submodule update --init
 $ mkdir build
 $ cd build
 $ cmake ..


### PR DESCRIPTION
One can't clone submodules with the command `git submodule update`
before running `git submodule init`. This commit ensures to initialize
submodules before updating them.